### PR TITLE
Fallback to ent:GetCreator() when ent.FPPOwner is nil

### DIFF
--- a/lua/fpp/server/ownability.lua
+++ b/lua/fpp/server/ownability.lua
@@ -250,7 +250,7 @@ function FPP.plyCanTouchEnt(ply, ent, touchType)
 end
 
 function FPP.entGetOwner(ent)
-    return ent.FPPOwner
+    return ent.FPPOwner or (IsValid(ent:GetCreator()) and ent:GetCreator():IsPlayer() and ent:GetCreator()) or nil
 end
 
 /*---------------------------------------------------------------------------


### PR DESCRIPTION
This means that addons that use SetCreator() for ownability will now be compatible with FPP.